### PR TITLE
feat: add MCP Doctor to Security Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It allows AI models to safely communicate with and control your local security t
 - [Nuclei MCP](https://github.com/addcontent/nuclei-mcp) – Fast vulnerability scanning with Nuclei via MCP.
 - [Illumio MCP](https://github.com/alexgoller/illumio-mcp-server) – AI-driven workload management and traffic flow analysis.
 - [ZAP Mcp](https://github.com/dtkmn/mcp-zap-server) - Exposes ZAP actions as MCP tools. Eliminates manual CLI calls and brittle scripts.
+- [MCP Doctor](https://github.com/xlyoung/mcp-doctor) – Scan, score, and install MCP servers with security checks. 8 detection engines + curated registry of 100+ servers.
 - [MCP Doctor](https://github.com/xlyoung/mcp-doctor) – Scan, score, and install MCP servers with security checks. 10 detection engines, quality scoring (0-100), and curated registry of 100+ servers.
 
 ---

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ It allows AI models to safely communicate with and control your local security t
 - [AICA Agent](https://github.com/aica-iwg/aica-agent) – Autonomous intelligent cyberdefense agent.
 - [Pentagi](https://github.com/vxcontrol/pentagi) – Fully autonomous AI-powered penetration testing agent.
 - [Agentic Security Scanner](https://github.com/msoedov/agentic_security) – Vulnerability scanner for Agent Workflows and LLMs.
+- **[MCP Doctor](https://github.com/xlyoung/mcp-doctor)** – Scan, score, and install MCP servers with 9 security detection engines, quality scoring (0-100), and curated registry of 200+ pre-scored servers.
 ## 🤝 Contributing
 Want to add your MCP or improve this list?  
 Check out [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It allows AI models to safely communicate with and control your local security t
 - [Nuclei MCP](https://github.com/addcontent/nuclei-mcp) – Fast vulnerability scanning with Nuclei via MCP.
 - [Illumio MCP](https://github.com/alexgoller/illumio-mcp-server) – AI-driven workload management and traffic flow analysis.
 - [ZAP Mcp](https://github.com/dtkmn/mcp-zap-server) - Exposes ZAP actions as MCP tools. Eliminates manual CLI calls and brittle scripts.
+- [MCP Doctor](https://github.com/xlyoung/mcp-doctor) – Scan, score, and install MCP servers with security checks. 10 detection engines, quality scoring (0-100), and curated registry of 100+ servers.
 
 ---
 


### PR DESCRIPTION
## What

Add [MCP Doctor](https://github.com/xlyoung/mcp-doctor) to the 🔐 Security Tools section.

## Why

MCP Doctor is a CLI tool that helps security professionals **vet MCP servers before installation** — a perfect complement to this list's security-focused mission.

**Key capabilities:**
- **8 security detection engines**: prompt injection, path traversal, SSRF, credential leakage, command injection, supply chain risks, excessive permissions, network exfiltration
- **Quality scoring (0-100)**: automated scoring across security (35%), maintenance (25%), documentation (15%), testing (15%), community (10%)
- **Curated registry**: 200+ pre-scored MCP servers with categories
- **One-command install**: `mcpdoctor install <server>` with security gate

This complements existing tools like AgentFence (agent testing) and Agentic Security Scanner (workflow scanning) by focusing on **MCP server vetting** — the supply chain security layer.

Install: `pip install mcpdoctor`